### PR TITLE
Implementing the template renderer for #8

### DIFF
--- a/gen/main.go
+++ b/gen/main.go
@@ -1,0 +1,67 @@
+package gen
+
+import (
+	"github.com/joncalhoun/pipe"
+	"io"
+	"io/ioutil"
+	"log"
+	"os/exec"
+	"text/template"
+)
+
+type Renderer interface {
+	Render(buffer io.Writer) error
+	PipeTo(command string, arg ...string)
+}
+
+type renderer struct {
+	template        string
+	data            interface{}
+	commandPipeline []*exec.Cmd
+}
+
+func (r *renderer) PipeTo(command string, arg ...string) {
+	r.commandPipeline = append(r.commandPipeline, exec.Command(command, arg...))
+}
+
+func (r renderer) Render(buffer io.Writer) error {
+	t := template.Must(template.New("fsm").Parse(r.template))
+
+	if len(r.commandPipeline) == 0 {
+		// If there are no commands in the pipeline, simply render the template
+		return t.Execute(buffer, &r.data)
+	} else {
+		// Otherwise we need to render, then pipe the output through the commands in the list
+		rc, wc, _ := pipe.Commands(
+			r.commandPipeline...,
+		)
+		err := t.Execute(wc, &r.data)
+		if err != nil {
+			return err
+		}
+
+		err = wc.Close()
+		if err != nil {
+			return err
+		}
+
+		_, err = io.Copy(buffer, rc)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func NewRenderer(template io.Reader, data interface{}) Renderer {
+	buf, err := ioutil.ReadAll(template)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return &renderer{
+		template: string(buf),
+		data:     data,
+	}
+}

--- a/gen/main_test.go
+++ b/gen/main_test.go
@@ -1,0 +1,86 @@
+package gen_test
+
+import (
+	"bytes"
+	"github.com/nicklarsennz/dot-fsm/gen"
+	"strings"
+	"testing"
+)
+
+func TestTemplateRender(t *testing.T) {
+	template := `
+{{range .Transitions -}}
+{{.Name}}
+{{end -}}
+`
+	expected := `
+t1
+t2
+`
+	templateData := struct {
+		Transitions []struct {
+			Name string
+		}
+	}{
+		Transitions: []struct{ Name string }{
+			{Name: "t1"},
+			{Name: "t2"},
+		},
+	}
+
+	byteWriter := bytes.NewBuffer([]byte{})
+	stringReader := strings.NewReader(template)
+
+	renderer := gen.NewRenderer(stringReader, templateData)
+	err := renderer.Render(byteWriter)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual := byteWriter.String()
+
+	if actual != expected {
+		t.Fatalf("rendering the template failed. Expected '%s', got '%s'", expected, actual)
+	}
+}
+
+func TestTemplateRenderWithCommands(t *testing.T) {
+	template := `
+
+
+ package gen
+
+   func {{.Thing}}()     {
+_ = 0
+ }
+
+
+`
+	expected := `package gen
+
+func blah() {
+	_ = 0
+}
+`
+	templateData := struct {
+		Thing string
+	}{
+		Thing: "blah",
+	}
+
+	byteWriter := bytes.NewBuffer([]byte{})
+	stringReader := strings.NewReader(template)
+
+	renderer := gen.NewRenderer(stringReader, templateData)
+	renderer.PipeTo("gofmt")
+	err := renderer.Render(byteWriter)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actual := byteWriter.String()
+
+	if actual != expected {
+		t.Fatalf("rendering the template failed. Expected '%s', got '%s'", expected, actual)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.12
 
 require (
 	github.com/google/go-cmp v0.3.0
+	github.com/joncalhoun/pipe v0.0.0-20170510025636-72505674a733
 	gonum.org/v1/gonum v0.0.0-20190710053202-4340aa3071a0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/joncalhoun/pipe v0.0.0-20170510025636-72505674a733 h1:/wtaMDeVpoAUkqZl/GT3lvM9nDBmRApu/Uvl7EUc9Ao=
+github.com/joncalhoun/pipe v0.0.0-20170510025636-72505674a733/go.mod h1:2MNFZhLx2HMHTN4xKH6FhpoQWqmD8Ato8QOE2hp5hY4=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/tools v0.0.0-20190206041539-40960b6deb8e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gonum.org/v1/gonum v0.0.0-20190710053202-4340aa3071a0 h1:2qZ38BsejXrhuetzb8UxucqrWDZKjypFSZA82hLCpZ4=


### PR DESCRIPTION
- Abstracted code generation so we can generate FSM code for more than one
FSM library
- Allow post processing commands in a pipeline
- Closes #5
- Closes #8